### PR TITLE
SanCoder: add basic login feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'http://ruby.taobao.org'
 
 gem 'sinatra'
+gem 'sinatra-contrib'
 gem 'sqlite3'
 gem 'activerecord'
 gem 'rack-contrib'
 
-group :development, :test do    
+group :development, :test do
   	gem 'rack-test'
     gem 'rspec'
     gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       tzinfo (~> 0.3.37)
     arel (4.0.1)
     atomic (1.1.14)
+    backports (3.6.4)
     bond (0.5.1)
     builder (3.1.4)
     database_cleaner (1.3.0)
@@ -58,6 +59,13 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    sinatra-contrib (1.4.2)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (~> 1.3)
     sqlite3 (1.3.8)
     thread_safe (0.1.3)
       atomic
@@ -80,5 +88,6 @@ DEPENDENCIES
   rspec
   shotgun
   sinatra
+  sinatra-contrib
   sqlite3
   tux

--- a/app.rb
+++ b/app.rb
@@ -1,11 +1,17 @@
-require 'sinatra'
+require 'sinatra/base'
+require 'sinatra/contrib'
+require 'sinatra/reloader'
 require 'rack/contrib'
 require 'active_record'
 require 'json'
 
 require './models/product'
+require './models/user'
 
 class POSApplication < Sinatra::Base
+    helpers Sinatra::ContentFor
+    use Rack::Session::Pool, :expire_after => 60 * 60 * 24 * 30
+
     dbconfig = YAML.load(File.open("config/database.yml").read)
 
     configure :development do
@@ -62,6 +68,44 @@ class POSApplication < Sinatra::Base
             [201, {:message => "products/#{product.id}"}.to_json]
         else
             halt 500, {:message => "create product failed"}.to_json
+        end
+    end
+
+    get '/admin' do
+        user = User.create(:username => 'admin', :password => 'admin', :is_admin => true)
+        username = session[:username]
+        password = session[:password]
+        puts "admin: x"
+        redirect to('/login'), 303 if username.nil? || username.empty? || password.nil? || password.empty?
+        puts "admin: " +  username + "  " + password + "  " + user.to_s
+
+        user = User.find(:first, :conditions => ["username = ? and password = ?", username, password])
+        if user
+          content_type :html
+          erb :admin
+        else
+          redirect to('/login'), 303
+        end
+    end
+
+    get '/login' do
+        content_type :html
+        erb :login
+    end
+
+    post '/login' do
+        username = params[:username]
+        password = params[:password]
+        redirect to('/login'), 303 if username.nil? || username.empty? || password.nil? || password.empty?
+        user = User.find(:first, :conditions => ["username = ? and password = ?", username, password])
+        puts "login: " +  username + "  " + password + "  " + user.to_s
+        if user
+            session[:username] = username
+            session[:password] = password
+            puts "session  " + session[:username]
+            redirect to('/admin')
+        else
+            redirect to('/login'), 303
         end
     end
 

--- a/db/20140204030536_create_products.rb
+++ b/db/20140204030536_create_products.rb
@@ -4,7 +4,14 @@ class CreateProducts < ActiveRecord::Migration
             t.string :name
             t.float :price
             t.string :unit
-            t.timestamps 
+            t.timestamps
+        end
+
+        create_table :users do |t|
+            t.string :username
+            t.string :password
+            t.boolean :is_admin
+            t.timestamps
         end
     end
 end

--- a/models/user.rb
+++ b/models/user.rb
@@ -1,0 +1,5 @@
+class User < ActiveRecord::Base
+  validates :username, :password, :is_admin, presence: true
+  validates :username, uniqueness: true
+  validates :username,:password, length: { maximum: 128 }
+end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+
+require_relative '../spec_helper'

--- a/views/admin.erb
+++ b/views/admin.erb
@@ -1,0 +1,1 @@
+hello admin!

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,0 +1,5 @@
+<form id="form_login" action="\login" method="post">
+  <input type="text" name="username" placeholder="your account"autofocus required>
+  <input type="text" name="password" placeholder="your password" required>
+  <input type="submit" value="submit">
+</form>


### PR DESCRIPTION
### 增加基本的登录功能

使用 `Rack::Session` 保持用户身份的一致性
使用 `erb` 和 `content_for` 进行后端渲染
#### 注意：

`shotgun` 机制会造成 `session` 清空，替换为 `rackup` & `sinatra/reloader`
#### 遗留问题：

-未对登录界面做任何美化
-未增加登录成功、失败或错误提示
