### PR TITLE
SanCoder: add a message prompt when an error occurs during the login

### DIFF
--- a/public/styles/login.css
+++ b/public/styles/login.css
@@ -31,3 +31,6 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+.form-error-text {
+  color: #A00;
+}

--- a/views/login.erb
+++ b/views/login.erb
@@ -35,6 +35,9 @@
 <!-- 页面主体 -->
   <form class="form-signin" id="form_login" action="\login" method="post">
     <h2 class="form-signin-heading">Please sign in</h2>
+    <% if !@error_text.nil? %>
+      <p class="form-error-text"><%= "#{@error_text} 请重新输入!"%></p>
+    <% end %>
     <input class="form-control" type="text" name="username" placeholder="Account"autofocus required>
     <input class="form-control" type="password" name="password" placeholder="Password" required>
     <input class="login-form-btn btn btn-lg btn-primary btn-block" type="submit" value="submit">


### PR DESCRIPTION
### 增加错误消息提示

当登录输入的用户名密码有误，或用户使用不支持HTML5浏览器越过浏览器表单验证而将空的用户名或密码递交至server时，将提示相应错误信息，并要求用户重新输入。
