### PR TITLE
SanCoder: fix a bug using back slash that should use slash in login.erb

### DIFF
--- a/views/login.erb
+++ b/views/login.erb
@@ -33,7 +33,7 @@
 <% end %>
 
 <!-- 页面主体 -->
-  <form class="form-signin" id="form_login" action="\login" method="post">
+  <form class="form-signin" id="form_login" action="/login" method="post">
     <h2 class="form-signin-heading">Please sign in</h2>
     <% if !@error_text.nil? %>
       <p class="form-error-text"><%= "#{@error_text} 请重新输入!"%></p>


### PR DESCRIPTION
### 修复 `login.erb` 使用反斜杠url的bug
