### PR TITLE
[#012][SanCoder] - add admin order and admin order detail

### DIFF
--- a/db/20140204030536_create_products.rb
+++ b/db/20140204030536_create_products.rb
@@ -4,7 +4,7 @@ class CreateProducts < ActiveRecord::Migration
             t.string :name
             t.float :price
             t.string :unit
-	        t.boolean :promotion
+            t.boolean :promotion
             t.integer :stock
             t.string :detail
             t.timestamps

--- a/db/20141214212915_create_order.rb
+++ b/db/20141214212915_create_order.rb
@@ -1,6 +1,8 @@
 class CreateOrder < ActiveRecord::Migration
 	def change
 		create_table :orders do |t|
+			t.float :sum_price, :default => 0.0
+			t.float :sum_discount, :default => 0.0
 			t.timestamps
 		end
 	end

--- a/db/20141214233352_create_trade_association.rb
+++ b/db/20141214233352_create_trade_association.rb
@@ -1,0 +1,12 @@
+class CreateTradeAssociation < ActiveRecord::Migration
+	def change
+ 		create_table "trade_associations" do |t|
+ 			t.integer :order_id, null: false
+ 			t.integer :product_id, null: false
+ 			t.float :kindred_price, :default => 0.0
+			t.float :unit_price, :default => 0.0
+ 			t.integer :amount, :default => 0
+ 			t.boolean :is_promotion, :default => false
+ 		end
+	end
+end

--- a/db/20141214633352_create_trade_promotion_association.rb
+++ b/db/20141214633352_create_trade_promotion_association.rb
@@ -1,0 +1,10 @@
+class CreateTradePromotionAssociation < ActiveRecord::Migration
+	def change
+ 		create_table "trade_promotion_associations" do |t|
+ 			t.integer :order_id, null: false
+ 			t.integer :product_id, null: false
+			t.float :discount_price, :default => 0.0
+			t.integer :discount_amount, :default => 0
+ 		end
+	end
+end

--- a/models/order.rb
+++ b/models/order.rb
@@ -3,12 +3,21 @@ require 'json'
 require_relative './product'
 
 class Order < ActiveRecord::Base
-    attr_reader :product_list, :discount_list, :sum_price, :sum_discount
-    def initialize
+    has_many :trade_associations, class_name: "TradeAssociation", dependent: :destroy
+    has_many :products, through: :trade_associations
+
+    has_many :promotion_associations, class_name: "TradePromotionAssociation", dependent: :destroy
+    has_many :promotion_products, through: :promotion_associations, source: :product
+
+    validates :create_time, presence: true
+    
+    after_initialize :init
+
+    attr_reader :product_list, :discount_list
+
+    def init
         @product_list = []
         @discount_list = []
-        @sum_price = 0.0
-        @sum_discount = 0.0
     end
 
     def init_with_data cart_data
@@ -60,14 +69,35 @@ class Order < ActiveRecord::Base
                 if discount_amount
                     item.discount_amount = discount_amount
                     @discount_list.push item
-                    @sum_discount += item.price * item.discount_amount
+                    self.sum_discount += item.price * item.discount_amount
                 end
             else
                 item.kindred_price = item.price * item.amount
             end
-            @sum_price += item.kindred_price
+            self.sum_price += item.kindred_price
         end
-        @sum_price
+        self.sum_price
     end
 
+    def save
+        @product_list.each do |product|
+            next if self.products.include? product
+            self.products.push product 
+            self.trade_associations.last.kindred_price = product.kindred_price
+            self.trade_associations.last.amount = product.amount
+            self.trade_associations.last.unit_price = product.price
+            self.trade_associations.last.is_promotion = product.promotion
+        end
+        @discount_list.each do |product|
+            next if self.promotion_products.include? product
+            self.promotion_products.push product
+            self.promotion_associations.last.discount_amount = product.discount_amount
+            self.promotion_associations.last.discount_price = product.discount_amount * product.price
+        end
+        super
+    end
+end
+
+class <<Order
+    undef :create
 end

--- a/models/product.rb
+++ b/models/product.rb
@@ -1,4 +1,10 @@
 class Product < ActiveRecord::Base
+	has_many :trade_associations, class_name: "TradeAssociation", dependent: :destroy
+	has_many :relative_orders, through: :trade_associations
+
+	has_many :trade_promotion_associations, class_name: "TradePromotionAssociation", dependent: :destroy
+	has_many :relative_promotion_orders, through: :trade_promotion_associations
+
 	attr_accessor :kindred_price, :amount, :discount_amount
 	@kindred_price = 0
 	@amount = 0

--- a/models/trade_association.rb
+++ b/models/trade_association.rb
@@ -1,0 +1,5 @@
+class TradeAssociation < ActiveRecord::Base
+	self.table_name = "trade_associations"
+	belongs_to :product, :foreign_key => "product_id", :class_name => "Product" 
+	belongs_to :order, :foreign_key => "order_id", :class_name => "Order" 
+end

--- a/models/trade_promotion_association.rb
+++ b/models/trade_promotion_association.rb
@@ -1,0 +1,5 @@
+class TradePromotionAssociation < ActiveRecord::Base
+	self.table_name = "trade_promotion_associations"
+	belongs_to :product, :foreign_key => "product_id", :class_name => "Product" 
+	belongs_to :order, :foreign_key => "order_id", :class_name => "Order" 
+end

--- a/public/scripts/model/cart.js
+++ b/public/scripts/model/cart.js
@@ -18,6 +18,7 @@ $(document).ready(function () {
         postForm.appendChild(postText);
         document.body.appendChild(postForm);
         postForm.submit();
+        window.sessionStorage.clear();
         return false;
 	});
 });

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -19,3 +19,19 @@ body{
 .promotion {
   width: 15%;
 }
+.order-id, .order-time {
+  font-size: 120%;
+  font-weight: bold;
+  margin: 5px;
+}
+.order-time {
+	margin-bottom: 10px;
+}
+.order-sum-row {
+	font-size: 105%;
+	font-weight: bold;
+	margin-top: 10px;
+}
+.order-back {
+	margin-bottom: 20px;
+}

--- a/spec/features/cart_spec.rb
+++ b/spec/features/cart_spec.rb
@@ -17,10 +17,10 @@ feature 'shopping cart page' do
 
     feature 'given an empty cart' do
         scenario "should get correct shopping list and price when a user add 3瓶雪碧 and 3斤苹果 in cart and visit '/cart'", js: true do
-            visit '/views/items.html'
+            visit '/items'
             (1..3).each do page.find(:xpath, '//button[../../td[contains(.,"雪碧")]]').click end
             (1..3).each do page.find(:xpath, '//button[../../td[contains(.,"苹果")]]').click end
-            visit '/views/cart.html'
+            visit '/cart'
             expect(page).to have_selector(:xpath, '//td[../td[contains(.,"雪碧")]][contains(.,"6.00")]')
             expect(page).to have_selector(:xpath, '//td[../td[contains(.,"苹果")]][contains(.,"16.50")]')
             expect(page).to have_selector('#totalPrice', text: '22.5')
@@ -31,9 +31,9 @@ feature 'shopping cart page' do
         scenario "should get correct shopping list and price when a user continully add 3瓶雪碧 in nonempty cart and visit '/cart'", js: true do
             visit '/'
             page.execute_script 'sessionStorage.count=6; sessionStorage.itemCount=JSON.stringify({"2":3,"3":3});'
-            visit '/views/items.html'
+            visit '/items'
             (1..3).each do page.find(:xpath, '//button[../../td[contains(.,"雪碧")]]').click end
-            visit '/views/cart.html'
+            visit '/cart'
             expect(page).to have_selector(:xpath, '//td[../td[contains(.,"雪碧")]][contains(.,"12.00")]')
             expect(page).to have_selector(:xpath, '//td[../td[contains(.,"苹果")]][contains(.,"16.50")]')
             expect(page).to have_selector('#totalPrice', text: '28.5')
@@ -44,7 +44,7 @@ feature 'shopping cart page' do
             page.execute_script 'sessionStorage.count=6; sessionStorage.itemCount=JSON.stringify({"2":3,"3":3});'
             # restart Selenium driver
             Capybara.send(:session_pool).delete_if { |key, value| key =~ /selenium/i }
-            visit '/views/cart.html'
+            visit '/cart'
             expect(page.find(:xpath, '//tbody[..[contains(@id,"item_list")]]').text).to eq("")
             expect(page).to have_selector('#totalPrice', text: '0.0')
         end
@@ -52,7 +52,7 @@ feature 'shopping cart page' do
         scenario "sum price should change correspondingly when a user visit '/cart' and change the amount of 苹果 in nonempty cart", js: true do
             visit '/'
             page.execute_script 'sessionStorage.count=6; sessionStorage.itemCount=JSON.stringify({"2":3,"3":3});'
-            visit '/views/cart.html'
+            visit '/cart'
             page.find(:xpath, '//button[contains(.,"+")][./ancestor::tr/td[contains(.,"雪碧")]]').click
             expect(page.find(:xpath, '//input[./ancestor::tr/td[contains(.,"雪碧")]]').value).to eq("4")
             expect(page).to have_selector('#totalPrice', text: '25.5')

--- a/spec/unit/order_spec.rb
+++ b/spec/unit/order_spec.rb
@@ -21,7 +21,7 @@ describe 'Order model' do
     describe 'initalize method' do
         it 'should get an empty shopping list when initializing with empty cart data' do
             cart_data = {}
-            order = Order.new()
+            order = Order.new
             order.init_with_data cart_data
             expect(order.product_list.length).to eq(0)
         end

--- a/views/admin.erb
+++ b/views/admin.erb
@@ -20,6 +20,7 @@
     <li>
       <a href="/items">商品列表</a>
     </li>
+    <li><a href="/order_admin">订单管理</a></li>
   </ul>
   <ul class="navbar-nav nav navbar-right">
     <li>

--- a/views/order_admin.erb
+++ b/views/order_admin.erb
@@ -1,0 +1,69 @@
+<% content_for :style_chunk do%>
+    <link rel="stylesheet" href="../styles/main.css"/>
+<% end %>
+<% content_for :nav_lis do%>
+<div class="navbar-header">
+  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+    <span class="sr-only">切换导航</span>
+    <span class="icon-bar"></span>
+    <span class="icon-bar"></span>
+    <span class="icon-bar"></span>
+  </button>
+  <a href="/items" class="navbar-brand">Let's Go</a>
+</div>
+<div class="navbar-collapse collapse">
+  <ul class="nav navbar-nav">
+    <li>
+      <a href="/">主页</a>
+    </li>
+    <li>
+      <a href="/items">商品列表</a>
+    </li>
+    <li class="active"><a href="/order_admin">订单管理</a></li>
+  </ul>
+  <ul class="navbar-nav nav navbar-right">
+    <li>
+      <a href="/cart" ><span class="glyphicon glyphicon-shopping-cart"></span>购物车 (<span id="count">0</span>)</a>
+    </li>
+    <li>
+      <a href="/admin">管理</a>
+    </li>
+  </ul>
+</div>
+<% end %>
+
+<!-- 页面主体 -->
+<div class="panel panel-success">
+  <div class="panel-heading"><h4>购物清单</h4></div>
+  <div id="pay-date"></div>
+  <table class="table table-bordered table-hover table-responsive">
+    <thead>
+      <tr>
+        <th>订单编号</th>
+        <th>订单时间</th>
+        <th>订单金额</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% orders.each do |order| %>
+        <tr>
+          <td>
+            <%= "##{format("%012d", order.id)}" %>
+          </td>
+          <td>
+            <%= "#{order.created_at}" %>
+          </td>
+          <td>
+            <%= "#{order.sum_price}" %>
+          </td>
+          <td>
+            <a <%= "href=\'/order_admin?id=#{order.id}\'"%>>订单详情</a>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+    <tfoot>
+    </tfoot>
+  </table>
+</div>

--- a/views/order_detail_admin.erb
+++ b/views/order_detail_admin.erb
@@ -19,6 +19,7 @@
     <li>
       <a href="/items">商品列表</a>
     </li>
+    <li class="active"><a href="/order_admin">订单管理</a></li>
   </ul>
   <ul class="navbar-nav nav navbar-right">
     <li>
@@ -32,6 +33,7 @@
 <% end %>
 
 <!-- 页面主体 -->
+<div class="order-back"><a href="/order_admin" class="btn btn-success">返回</a></div>
 <div class="order-id"><%= "订单编号 : ##{format("%012d", order.id)}".gsub(/\s/, "&nbsp;&nbsp;")%></div>
 <div class="order-time"><%= "订单时间 : #{order.created_at}".gsub(/\s/, "&nbsp;&nbsp;")%></div>
 <div class="panel panel-success">
@@ -110,7 +112,6 @@
         <ul class="list-unstyled order-sum-row">
           <li class="text-right"><p><%= "订单金额：#{format("%10.2f", order.sum_price)} 元".gsub(/\s/, "&nbsp;&nbsp;") %></p></li>
           <li class="text-right"><p><%= "折扣金额：#{format("%10.2f", order.sum_discount)} 元".gsub(/\s/, "&nbsp;&nbsp;") %></p></li>
-          <li class="text-right"><a href="/items" class="btn btn-success">确认</a></li>
         </ul>
       </td>
     </tfoot>


### PR DESCRIPTION
### 增加订单管理功能
- 增加订单管理页面（`order_admin.erb`）
- 增加订单详情页面（`order_detail_admin.erb`）
- 增加数据模型：订单（`Order`）
- 增加数据关系模型：交易关系（`order <-> product`）
- 增加数据关系模型：交易折扣关系（`order <-> product`）
- 更新支付页面数据访问逻辑（`payment.erb`）
